### PR TITLE
Valid BTW-nummer

### DIFF
--- a/index.html
+++ b/index.html
@@ -153,7 +153,7 @@
                         </p>
                         <p>
                             KVK-nummer: 40397267 <br>
-                            BTW-nummer: NL5359582B01
+                            BTW-nummer: NL005359582B01
                         </p>
                     </div>
                     <div class="col-md-9">


### PR DESCRIPTION
Use trailing zeros after NL to make it 14 digits long. See http://www.belastingdienst.nl/wps/wcm/connect/bldcontentnl/belastingdienst/zakelijk/btw/administratie_bijhouden/btw_nummers_controleren/uw_btw_nummer
